### PR TITLE
don't change the default of indent-tabs-mode

### DIFF
--- a/better-defaults.el
+++ b/better-defaults.el
@@ -71,7 +71,6 @@
   (global-set-key (kbd "C-M-r") 'isearch-backward)
 
   (show-paren-mode 1)
-  (setq-default indent-tabs-mode nil)
   (setq x-select-enable-clipboard t
         x-select-enable-primary t
         save-interprogram-paste-before-kill t


### PR DESCRIPTION
This is a very disruptive default change. There are many codebases (Linux, for example) that use tabs. Changing this default prevents a user from using the most straightforward way to use Linux style, because they also need to change this option, which is never mentioned in tutorials on how to set your style to match Linux style.

For me, personally, this has led to some embarrassments where I thought my style was set to Linux style, but in fact this changed default was converting the tabs to spaces, so when I submitted those patches someone had to tell me to fix my novice mistake.

This default would never get into core Emacs, and I don't think it should. Don't surprise users by silently performing such a radical change to Emacs styling; I only knew the way to fix it by guessing that better-defaults might have done something like this. The presence of this setting means that I can't recommend better-defaults to the less-informed.

Instead of doing this, we should change the defaults for c-default-style and other style variables, as appropriate. Again: (setq-default indent-tabs-mode nil) breaks those variables, preventing them from actually fully changing the style. That can't be anything other than a bug.