### PR TITLE
Disable Horizontal Scroll Bar

### DIFF
--- a/better-defaults.el
+++ b/better-defaults.el
@@ -51,6 +51,8 @@
     (tool-bar-mode -1))
   (when (fboundp 'scroll-bar-mode)
     (scroll-bar-mode -1))
+  (when (fboundp 'horizontal-scroll-bar-mode)
+    (horizontal-scroll-bar-mode -1))
 
   (autoload 'zap-up-to-char "misc"
     "Kill up to, but not including ARGth occurrence of CHAR." t)


### PR DESCRIPTION
Emacs 25 has horizontal scroll bars that are enabled by default. At least, on my Emacs it is. This patch disables it to reclaim real estate.