### PR TITLE
Replace obsolete variables x-select-enable-clipboard and x-select-enable-primary

### DIFF
--- a/better-defaults.el
+++ b/better-defaults.el
@@ -75,8 +75,8 @@
 
   (show-paren-mode 1)
   (setq-default indent-tabs-mode nil)
-  (setq x-select-enable-clipboard t
-        x-select-enable-primary t
+  (setq select-enable-clipboard t
+        select-enable-primary t
         save-interprogram-paste-before-kill t
         apropos-do-all t
         mouse-yank-at-point t


### PR DESCRIPTION
```
better-defaults.el:79:9:Warning: ‘x-select-enable-clipboard’ is an obsolete
    variable (as of 25.1); use ‘select-enable-clipboard’ instead.
better-defaults.el:80:9:Warning: ‘x-select-enable-primary’ is an obsolete
    variable (as of 25.1); use ‘select-enable-primary’ instead.
```