### PR TITLE
Disable Ido if Ivy is available.

### DIFF
--- a/better-defaults.el
+++ b/better-defaults.el
@@ -42,7 +42,7 @@
 ;;; Code:
 
 (progn
-  (unless (fboundp 'helm-mode)
+  (unless (or (fboundp 'helm-mode) (fboundp 'ivy-mode))
     (ido-mode t)
     (setq ido-enable-flex-matching t))
 


### PR DESCRIPTION
Used `or`, per https://github.com/technomancy/better-defaults/pull/25. Addresses https://github.com/technomancy/better-defaults/issues/24.