### PR TITLE
Allow menus when using OsX.

### DIFF
--- a/better-defaults.el
+++ b/better-defaults.el
@@ -46,7 +46,8 @@
     (ido-mode t)
     (setq ido-enable-flex-matching t))
 
-  (menu-bar-mode -1)
+  (unless (eq window-system 'ns)
+    (menu-bar-mode -1))
   (when (fboundp 'tool-bar-mode)
     (tool-bar-mode -1))
   (when (fboundp 'scroll-bar-mode)


### PR DESCRIPTION
Rationale: on a Mac, the menu doesn't take window space.