### PR TITLE
Updated Save Place activation to support GNU Emacs 25.1 and newer ver…

### DIFF
--- a/better-defaults.el
+++ b/better-defaults.el
@@ -61,8 +61,8 @@
   (require 'uniquify)
   (setq uniquify-buffer-name-style 'forward)
 
-  (require 'saveplace)
-  (setq-default save-place t)
+  ;; https://www.emacswiki.org/emacs/SavePlace
+  (save-place-mode 1)
 
   (global-set-key (kbd "M-/") 'hippie-expand)
   (global-set-key (kbd "C-x C-b") 'ibuffer)


### PR DESCRIPTION
Update the code to activate Save Place in order to support Emacs 25.1 and newer versions.